### PR TITLE
feat: Add Cat Cannon upgrade and fix scoring system

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -78,6 +78,13 @@ canvas { display: block; touch-action: none; }
 .btn-deposit { bottom: 175px; left: 22px; width: 64px; height: 64px; background: rgba(74,222,128,0.55); border: 3px solid rgba(74,222,128,0.7); font-size: 1.5rem; opacity: 0; transition: opacity 0.2s; pointer-events: none; }
 .btn-deposit.visible { opacity: 1; pointer-events: auto; }
 .btn-deposit:active { background: rgba(74,222,128,0.85); }
+.btn-cannon { bottom: 260px; right: 22px; width: 64px; height: 64px; background: rgba(220,80,80,0.55); border: 3px solid rgba(220,80,80,0.7); font-size: 1.5rem; opacity: 0; transition: opacity 0.2s; pointer-events: none; }
+.btn-cannon.visible { opacity: 1; pointer-events: auto; }
+.btn-cannon:active { background: rgba(220,80,80,0.85); }
+
+/* ===================== CANNON HUD INDICATOR ===================== */
+.cannon-toggle { background: rgba(220,80,80,0.4); border-radius: 12px; padding: 8px 16px; color: rgba(255,255,255,0.4); font-size: 0.9rem; font-family: 'Fredoka', sans-serif; border: 2px solid rgba(220,80,80,0.3); display: none; pointer-events: auto; cursor: pointer; transition: all 0.2s; }
+.cannon-toggle.active { background: rgba(220,80,80,0.7); color: #fff; border-color: rgba(255,100,100,0.8); }
 
 /* ===================== UPGRADE SCREEN ===================== */
 #upgrade-screen { position: fixed; inset: 0; z-index: 200; background: rgba(20,15,10,0.92); display: none; flex-direction: column; align-items: center; justify-content: center; padding: 20px; overflow-y: auto; }

--- a/index.html
+++ b/index.html
@@ -28,13 +28,14 @@
   <div class="hud-center-msg" id="center-msg"></div>
   <div class="catch-flash" id="catch-flash">Caught!</div>
   <div class="expand-flash" id="expand-flash"></div>
-  <div class="hud-bottom-center"><div class="hud-bag" id="bag-display">🐱 0 / 1</div></div>
+  <div class="hud-bottom-center"><div class="hud-bag" id="bag-display">🐱 0 / 1</div><div class="cannon-toggle" id="cannon-toggle">🔫 CANNON</div></div>
 </div>
 <div id="mobile-controls">
   <div class="joystick-zone" id="joystick-zone"><div class="joystick-base" id="joystick-base-left"></div><div class="joystick-knob" id="joystick-knob"></div></div>
   <div class="joystick-zone-right" id="joystick-zone-right"><div class="joystick-base" id="joystick-base-right" style="left:auto;right:20px;"></div><div class="joystick-knob" id="joystick-knob-right" style="left:auto;right:62px;"></div></div>
   <div class="mobile-btn btn-swing" id="btn-swing">🥅</div>
   <div class="mobile-btn btn-deposit" id="btn-deposit">📦</div>
+  <div class="mobile-btn btn-cannon" id="btn-cannon">🔫</div>
 </div>
 <div class="day-intro" id="day-intro"></div>
 <div id="upgrade-screen">

--- a/js/cats.js
+++ b/js/cats.js
@@ -71,4 +71,4 @@ function updateCat(cat, dt, playerPos) {
 
 function clampToRoom(pos, maxR) { const r=Math.sqrt(pos.x*pos.x+pos.z*pos.z); if(r>maxR){pos.x*=maxR/r;pos.z*=maxR/r;} }
 function clearCats() { for(const c of cats) scene.remove(c.mesh); cats.length=0; }
-function allCurrentCatsDone() { return cats.every(c=>c.caught) && state.catsInBag===0; }
+function allCurrentCatsDone() { return cats.every(c=>c.caught) && state.catsInBag===0 && projectileCats.length===0; }

--- a/js/controls.js
+++ b/js/controls.js
@@ -3,7 +3,8 @@ const keys={};let yaw=0,pitch=0,pointerLocked=false;
 document.addEventListener('keydown',e=>{keys[e.code]=true;});
 document.addEventListener('keyup',e=>{keys[e.code]=false;});
 document.addEventListener('mousemove',e=>{if(!pointerLocked||isMobile)return;yaw-=e.movementX*0.002;pitch-=e.movementY*0.002;pitch=Math.max(-Math.PI/2.2,Math.min(Math.PI/2.2,pitch));});
-document.addEventListener('mousedown',e=>{if(e.button===0&&pointerLocked&&state.phase==='PLAYING'&&!isMobile) startSwing();});
+document.addEventListener('mousedown',e=>{if(e.button===0&&pointerLocked&&state.phase==='PLAYING'&&!isMobile){if(state.cannonMode) shootCat(); else startSwing();}});
+document.addEventListener('keydown',e=>{if(e.code==='KeyQ'&&!e.repeat&&state.phase==='PLAYING'&&state.upgrades.catCannon) toggleCannonMode();});
 document.addEventListener('pointerlockchange',()=>{pointerLocked=document.pointerLockElement===renderer.domElement;if(!pointerLocked&&state.phase==='PLAYING'&&!isMobile){state.paused=true;document.getElementById('blocker').classList.remove('hidden');document.getElementById('blocker-prompt').textContent='Click to Resume';document.getElementById('blocker-subtitle').textContent='Game paused';}});
 function requestPointerLock(){if(!isMobile) renderer.domElement.requestPointerLock();}
 
@@ -27,7 +28,9 @@ function setupMobileControls(){
   }
   makeDJ('joystick-zone','joystick-base-left','joystick-knob',(x,y)=>{mobileInput.moveX=x;mobileInput.moveY=y;},()=>{mobileInput.moveX=0;mobileInput.moveY=0;});
   makeDJ('joystick-zone-right','joystick-base-right','joystick-knob-right',(x,y)=>{mobileInput.lookX=x;mobileInput.lookY=y;},()=>{mobileInput.lookX=0;mobileInput.lookY=0;});
-  btnSwing.addEventListener('touchstart',e=>{e.preventDefault();startSwing();},{passive:false});
+  btnSwing.addEventListener('touchstart',e=>{e.preventDefault();if(state.cannonMode) shootCat(); else startSwing();},{passive:false});
+  const btnCannon=document.getElementById('btn-cannon');
+  if(btnCannon) btnCannon.addEventListener('touchstart',e=>{e.preventDefault();toggleCannonMode();},{passive:false});
   btnDeposit.addEventListener('touchstart',e=>{e.preventDefault();if(isNearCrate())depositCats();},{passive:false});
   hudPause.addEventListener('touchstart',e=>{e.preventDefault();e.stopPropagation();state.paused=true;document.getElementById('blocker').classList.remove('hidden');document.getElementById('blocker-prompt').textContent='Tap to Resume';document.getElementById('blocker-subtitle').textContent='Game paused';if(isMobile)document.getElementById('settings-panel').classList.add('visible');},{passive:false});
   const sS=document.getElementById('setting-sensitivity'),sV=document.getElementById('sensitivity-value'),dS=document.getElementById('setting-deadzone'),dV=document.getElementById('deadzone-value');
@@ -60,8 +63,13 @@ function updatePlayer(dt) {
   camera.rotation.x = pitch + (camShakeIntensity>0 ? (Math.random()-0.5)*camShakeIntensity*0.5 : 0);
 
   if(!isMobile&&keys['KeyE']&&isNearCrate()) depositCats();
-  if(isMobile) document.getElementById('btn-deposit').classList.toggle('visible',isNearCrate()&&state.catsInBag>0);
+  if(isMobile){
+    document.getElementById('btn-deposit').classList.toggle('visible',isNearCrate()&&state.catsInBag>0);
+    const bc=document.getElementById('btn-cannon');
+    if(bc) bc.classList.toggle('visible',!!state.upgrades.catCannon);
+  }
   const nc=isNearCrate();
-  if(!isMobile){if(nc&&state.catsInBag>0) showCenterMsg("Press E to deposit"); else if(state.catsInBag>=getMaxBag()) showCenterMsg("Bag full! Return to crate"); else hideCenterMsg();}
+  if(state.cannonMode){if(state.catsInBag>0) showCenterMsg("Cannon mode! Click to shoot · Q to switch"); else showCenterMsg("No cats to shoot! Q to switch back");}
+  else if(!isMobile){if(nc&&state.catsInBag>0) showCenterMsg("Press E to deposit"+(state.upgrades.catCannon?" · Q for cannon":"")); else if(state.catsInBag>=getMaxBag()) showCenterMsg("Bag full! Return to crate"+(state.upgrades.catCannon?" or use cannon (Q)":"")); else hideCenterMsg();}
   else{if(state.catsInBag>=getMaxBag()&&!nc) showCenterMsg("Bag full! Return to crate"); else hideCenterMsg();}
 }

--- a/js/game.js
+++ b/js/game.js
@@ -2,13 +2,14 @@
 function startDay(){
   state.phase='PLAYING'; state.paused=false;
   state.timeLeft=DAY_DURATION; state.dayScore=0; state.catsInBag=0;
-  state.expanding=false; expandAnim=null; camShakeIntensity=0;
+  state.expanding=false; state.cannonMode=false; expandAnim=null; camShakeIntensity=0;
 
   state.activeDayRing = state.progressRing;
 
   camera.position.set(0,1.5,0); yaw=0; pitch=0;
 
   clearCats();
+  clearProjectileCats();
   buildRoomUpToRing(state.activeDayRing);
   spawnCatsForRing(state.activeDayRing);
 
@@ -16,6 +17,9 @@ function startDay(){
   if(isMobile) document.getElementById('mobile-controls').classList.add('active');
   document.getElementById('day-num').textContent=state.day;
   updateBagDisplay();updateScoreDisplay();updateTimerDisplay();updateRingDisplay();
+  const ct=document.getElementById('cannon-toggle');
+  if(ct){ct.style.display=state.upgrades.catCannon?'block':'none';ct.classList.remove('active');}
+  netGroup.visible=true;
   showDayIntro();hideCenterMsg();hideUpgradeScreen();
   if(!isMobile) requestPointerLock();
   startBgMusic();
@@ -23,8 +27,8 @@ function startDay(){
 
 function endDay(){
   state.phase='DAY_END';
-  state.dayScore+=state.catsInBag;state.totalScore+=state.catsInBag;
-  state.currency+=state.catsInBag;state.catsInBag=0;
+  state.catsInBag=0; state.cannonMode=false;
+  clearProjectileCats();
   document.getElementById('hud').classList.remove('active');
   document.getElementById('mobile-controls').classList.remove('active');
   if(!isMobile) document.exitPointerLock();
@@ -51,6 +55,7 @@ createCrate();
 createNet();
 if(isMobile) setupMobileControls();
 loadSoundManifest();
+document.getElementById('cannon-toggle').addEventListener('click',()=>toggleCannonMode());
 
 let lastTime=0;
 function gameLoop(time){
@@ -66,6 +71,7 @@ function gameLoop(time){
     const pp=new THREE.Vector3(camera.position.x,0,camera.position.z);
     for(const cat of cats) updateCat(cat,dt,pp);
     updateNet(dt);
+    updateProjectileCats(dt);
     if(!state.expanding) updateRingDisplay();
     if(crateMesh){const r=crateMesh.children[crateMesh.children.length-1];r.material.opacity=0.2+Math.sin(time*0.003)*0.1;}
   }

--- a/js/state.js
+++ b/js/state.js
@@ -2,12 +2,13 @@
 const state = {
   phase: 'MENU', day: 1, timeLeft: DAY_DURATION,
   dayScore: 0, totalScore: 0, currency: 0, catsInBag: 0,
-  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0 },
+  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, catCannon: 0 },
   paused: false,
   settings: { lookSensitivity: 2.5, deadZone: 0.15 },
   progressRing: 0,
   activeDayRing: 0,
   expanding: false,
+  cannonMode: false,
 };
 
 function getCurrentMaxRadius() { return ringOuterR(state.activeDayRing); }
@@ -15,6 +16,6 @@ function getNetRange() { return 3.5 + state.upgrades.netSize * 1.0; }
 function getNetAngle() { return 0.45 + state.upgrades.netSize * 0.1; }
 function getMoveSpeed() { return 4.0 + state.upgrades.walkSpeed * 1.0; }
 function getMaxBag() { return 1 + state.upgrades.bagSize; }
-function getUpgradeCost(type) { const l = state.upgrades[type]; return (l + 1) * 2 + Math.floor(l * 0.5); }
+function getUpgradeCost(type) { if (type === 'catCannon') return 16; const l = state.upgrades[type]; return (l + 1) * 2 + Math.floor(l * 0.5); }
 function getCatCountForRing(ring) { return Math.min(8 * Math.pow(2, ring), 128); }
 function getCatDifficulty(ring) { return 1 + ring * 0.35; }

--- a/js/ui.js
+++ b/js/ui.js
@@ -31,5 +31,17 @@ function renderUpgradeCards(){
     if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades[up.key]++;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();renderUpgradeCards();});
     c.appendChild(card);
   }
+  // Cat Cannon one-time unlock
+  if(!state.upgrades.catCannon){
+    const cost=getUpgradeCost('catCannon'),can=state.currency>=cost;
+    const card=document.createElement('div');card.className='upgrade-card'+(can?'':' disabled');
+    card.innerHTML=`<div class="upgrade-info"><div class="upgrade-name">🔫 Cat Cannon <span class="upgrade-level">Locked</span></div><div class="upgrade-desc">Shoot cats at the crate to deposit them from afar!</div></div><button class="upgrade-btn ${can?'':'cant-afford'}">${cost} 🐱</button>`;
+    if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades.catCannon=1;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();renderUpgradeCards();});
+    c.appendChild(card);
+  }
+}
+function updateCannonDisplay(){
+  const el=document.getElementById('cannon-toggle');
+  if(el) el.classList.toggle('active',state.cannonMode);
 }
 function hideUpgradeScreen(){document.getElementById('upgrade-screen').classList.remove('active');}


### PR DESCRIPTION
Adds an unlockable Cat Cannon (16 points) that lets players shoot collected cats at the crate to deposit them from afar. Missed shots respawn the cat as a roaming cat. Also fixes scoring so points only accumulate when cats are deposited at the crate, not when picked up.

Closes #4

Generated with [Claude Code](https://claude.ai/code)