### PR TITLE
feat: Use cat models from models folder with walking animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
 <script src="js/constants.js"></script>
 <script src="js/state.js"></script>
 <script src="js/sound.js"></script>

--- a/js/game.js
+++ b/js/game.js
@@ -55,6 +55,7 @@ createCrate();
 createNet();
 if(isMobile) setupMobileControls();
 loadSoundManifest();
+loadCatModels();
 document.getElementById('cannon-toggle').addEventListener('click',()=>toggleCannonMode());
 
 let lastTime=0;


### PR DESCRIPTION
Use GLB cat models from the `models/` folder instead of dynamically generated cats, with proper scaling and a soft side-to-side bounce walking animation. Falls back to procedural cats if models fail to load.

Closes #6

Generated with [Claude Code](https://claude.ai/code)