### PR TITLE
Add mobile full-screen mode toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -62,6 +62,12 @@ canvas { display: block; touch-action: none; }
 .hud-pause { display: none; font-size: 1.5rem; pointer-events: auto; cursor: pointer; padding: 4px 8px; opacity: 0.7; -webkit-tap-highlight-color: transparent; }
 @media (max-width: 600px) { .hud-pause { display: block; } }
 
+/* ===================== FULLSCREEN TOGGLE ===================== */
+.fullscreen-row { display: none; justify-content: center; margin-top: 8px; }
+.fullscreen-btn { background: rgba(232,130,42,0.6); color: #fff; border: 2px solid rgba(232,130,42,0.8); border-radius: 10px; padding: 10px 20px; font-family: 'Fredoka', sans-serif; font-size: 0.95rem; cursor: pointer; transition: background 0.2s; width: 100%; -webkit-tap-highlight-color: transparent; }
+.fullscreen-btn:active { background: rgba(232,130,42,0.9); }
+@media (max-width: 600px) { .fullscreen-row { display: flex; } }
+
 /* ===================== MOBILE CONTROLS ===================== */
 #mobile-controls { display: none; position: fixed; inset: 0; z-index: 15; pointer-events: none; }
 #mobile-controls.active { display: block; }

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <div class="settings-title">⚙️ Controls</div>
     <label class="setting-row"><span class="setting-label">Look Sensitivity</span><input type="range" id="setting-sensitivity" min="1" max="5" step="0.25" value="2.5"><span class="setting-value" id="sensitivity-value">2.5</span></label>
     <label class="setting-row"><span class="setting-label">Stick Dead Zone</span><input type="range" id="setting-deadzone" min="0.05" max="0.35" step="0.05" value="0.15"><span class="setting-value" id="deadzone-value">15%</span></label>
+    <div class="setting-row fullscreen-row" id="fullscreen-row"><button class="fullscreen-btn" id="fullscreen-btn">⛶ Enter Full Screen</button></div>
   </div>
 </div>
 <div id="hud">

--- a/js/ui.js
+++ b/js/ui.js
@@ -45,3 +45,29 @@ function updateCannonDisplay(){
   if(el) el.classList.toggle('active',state.cannonMode);
 }
 function hideUpgradeScreen(){document.getElementById('upgrade-screen').classList.remove('active');}
+
+// ===================== FULLSCREEN =====================
+function updateFullscreenBtn(){
+  const btn=document.getElementById('fullscreen-btn');
+  if(!btn)return;
+  const isFS=!!(document.fullscreenElement||document.webkitFullscreenElement);
+  btn.textContent=isFS?'⛶ Exit Full Screen':'⛶ Enter Full Screen';
+}
+function toggleFullscreen(){
+  const doc=document.documentElement;
+  if(document.fullscreenElement||document.webkitFullscreenElement){
+    if(document.exitFullscreen) document.exitFullscreen();
+    else if(document.webkitExitFullscreen) document.webkitExitFullscreen();
+  } else {
+    if(doc.requestFullscreen) doc.requestFullscreen();
+    else if(doc.webkitRequestFullscreen) doc.webkitRequestFullscreen();
+  }
+}
+(function initFullscreenBtn(){
+  const btn=document.getElementById('fullscreen-btn');
+  if(!btn)return;
+  btn.addEventListener('click',e=>{e.stopPropagation();toggleFullscreen();});
+  btn.addEventListener('touchend',e=>{e.preventDefault();e.stopPropagation();toggleFullscreen();},{passive:false});
+  document.addEventListener('fullscreenchange',updateFullscreenBtn);
+  document.addEventListener('webkitfullscreenchange',updateFullscreenBtn);
+})();


### PR DESCRIPTION
Adds a full-screen toggle button to the mobile start/pause menu settings panel.

Uses the Fullscreen API with webkit fallback for iOS Safari. The button is only visible on mobile viewports.

Closes #11

Generated with [Claude Code](https://claude.ai/code)