### PR TITLE
Fix missing comma in sounds.json preventing sound loading

### DIFF
--- a/sounds/sounds.json
+++ b/sounds/sounds.json
@@ -38,7 +38,7 @@
                     "sounds/purring/purring_1.mp3",
                     "sounds/purring/purring_2.mp3",
                     "sounds/purring/purring_3.mp3"
-                ]
+                ],
      "vacuum": [
          "sounds/vacuum/vacuum_0.mp3"
      ]


### PR DESCRIPTION
Fixes #14

The `sounds.json` manifest was missing a comma between the "purring" and "vacuum" entries, causing JSON parsing to fail silently. This prevented all sound files from being loaded, with the app falling back to synthesized sounds.

Generated with [Claude Code](https://claude.ai/code)