### PR TITLE
feat: add mobile controller options (Dual Analog / GoldenEye)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -63,6 +63,14 @@ canvas { display: block; touch-action: none; }
 .setting-label { flex: 1; min-width: 100px; }
 .setting-row input[type="range"] { flex: 1.2; accent-color: #E8822A; height: 6px; cursor: pointer; }
 .setting-value { min-width: 36px; text-align: right; font-family: 'Fredoka', sans-serif; color: #F7C948; font-size: 0.95rem; }
+/* ===================== CONTROLLER MODE TOGGLE ===================== */
+.controller-mode-row { display: none; flex-direction: column; gap: 8px; }
+@media (max-width: 600px) { .controller-mode-row { display: flex; } }
+.controller-toggle { display: flex; gap: 0; border-radius: 8px; overflow: hidden; border: 2px solid rgba(232,130,42,0.5); }
+.controller-option { flex: 1; background: rgba(255,255,255,0.05); color: #E8C9A0; border: none; font-family: 'Fredoka', sans-serif; font-size: 0.85rem; padding: 8px 12px; cursor: pointer; transition: background 0.2s, color 0.2s; -webkit-tap-highlight-color: transparent; }
+.controller-option.active { background: rgba(232,130,42,0.7); color: #fff; }
+.controller-option:not(.active):active { background: rgba(232,130,42,0.3); }
+
 .hud-pause { display: none; font-size: 1.5rem; pointer-events: auto; cursor: pointer; padding: 4px 8px; opacity: 0.7; -webkit-tap-highlight-color: transparent; }
 @media (max-width: 600px) { .hud-pause { display: block; } }
 
@@ -97,6 +105,10 @@ canvas { display: block; touch-action: none; }
 .btn-mouse { bottom: 260px; left: 22px; width: 64px; height: 64px; background: rgba(180,140,80,0.55); border: 3px solid rgba(180,140,80,0.7); font-size: 1.5rem; opacity: 0; transition: opacity 0.2s; pointer-events: none; }
 .btn-mouse.visible { opacity: 1; pointer-events: auto; }
 .btn-mouse:active { background: rgba(180,140,80,0.85); }
+.btn-aim { bottom: 50px; left: 50%; transform: translateX(-50%); width: 72px; height: 72px; background: rgba(160,160,220,0.45); border: 3px solid rgba(160,160,220,0.6); font-size: 1.5rem; display: none; }
+.btn-aim.visible { display: flex; }
+.btn-aim.held { background: rgba(160,160,220,0.85); border-color: rgba(200,200,255,0.9); }
+.btn-aim:active { background: rgba(160,160,220,0.85); }
 
 /* ===================== HUD INVENTORY INDICATOR ===================== */
 .hud-inventory { background: rgba(0,0,0,0.5); border-radius: 12px; padding: 8px 16px; color: #E8C9A0; font-size: 1rem; font-family: 'Fredoka', sans-serif; border: 2px solid rgba(180,140,80,0.4); }

--- a/index.html
+++ b/index.html
@@ -14,6 +14,13 @@
   <button class="continue-btn hidden" id="continue-btn">Continue (Day <span id="continue-day">1</span>)</button>
   <div class="settings-panel" id="settings-panel">
     <div class="settings-title">⚙️ Controls</div>
+    <div class="setting-row controller-mode-row" id="controller-mode-row">
+      <span class="setting-label">Controller</span>
+      <div class="controller-toggle" id="controller-toggle">
+        <button class="controller-option active" id="opt-dualAnalog" data-mode="dualAnalog">Dual Analog</button>
+        <button class="controller-option" id="opt-goldenEye" data-mode="goldenEye">GoldenEye</button>
+      </div>
+    </div>
     <label class="setting-row"><span class="setting-label">Look Sensitivity</span><input type="range" id="setting-sensitivity" min="1" max="5" step="0.25" value="2.5"><span class="setting-value" id="sensitivity-value">2.5</span></label>
     <label class="setting-row"><span class="setting-label">Stick Dead Zone</span><input type="range" id="setting-deadzone" min="0.05" max="0.35" step="0.05" value="0.15"><span class="setting-value" id="deadzone-value">15%</span></label>
     <div class="setting-row fullscreen-row" id="fullscreen-row"><button class="fullscreen-btn" id="fullscreen-btn">⛶ Enter Full Screen</button></div>
@@ -40,6 +47,7 @@
   <div class="mobile-btn btn-cannon" id="btn-cannon">🔫</div>
   <div class="mobile-btn btn-vacuum" id="btn-vacuum">🌀</div>
   <div class="mobile-btn btn-mouse" id="btn-mouse">🐭</div>
+  <div class="mobile-btn btn-aim" id="btn-aim"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/></svg></div>
 </div>
 <div class="day-intro" id="day-intro"></div>
 <div id="upgrade-screen">

--- a/js/game.js
+++ b/js/game.js
@@ -74,6 +74,7 @@ if(hasSavedGame()){
     const dzEl=document.getElementById('setting-deadzone');
     if(sensEl){sensEl.value=state.settings.lookSensitivity;document.getElementById('sensitivity-value').textContent=state.settings.lookSensitivity;}
     if(dzEl){dzEl.value=state.settings.deadZone;document.getElementById('deadzone-value').textContent=Math.round(state.settings.deadZone*100)+'%';}
+    if(isMobile) applyControllerMode();
     continueBtn.classList.add('hidden');
     document.getElementById('blocker').classList.add('hidden');
     document.getElementById('settings-panel').classList.remove('visible');
@@ -88,7 +89,7 @@ buildRoomUpToRing(0);
 createCrate();
 createNet();
 createVacuum();
-if(isMobile) setupMobileControls();
+if(isMobile){setupMobileControls();applyControllerMode();}
 loadSoundManifest();
 loadCatModels();
 document.getElementById('cannon-toggle').addEventListener('click',()=>toggleCannonMode());

--- a/js/state.js
+++ b/js/state.js
@@ -5,7 +5,7 @@ const state = {
   upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, catCannon: 0, catVacuum: 0 },
   inventory: { toyMouse: 0 },
   paused: false,
-  settings: { lookSensitivity: 2.5, deadZone: 0.15 },
+  settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'dualAnalog' },
   progressRing: 0,
   activeDayRing: 0,
   expanding: false,
@@ -57,6 +57,7 @@ function loadGame() {
     if (data.settings) {
       state.settings.lookSensitivity = data.settings.lookSensitivity ?? 2.5;
       state.settings.deadZone = data.settings.deadZone ?? 0.15;
+      state.settings.controllerMode = data.settings.controllerMode ?? 'dualAnalog';
     }
     return true;
   } catch(e) { return false; }


### PR DESCRIPTION
Add controller selection toggle to the mobile settings panel with two modes:
- **Dual Analog** (default): existing two-joystick layout
- **GoldenEye**: single joystick for movement, with a crosshair aim button that locks the stick to look mode when held

Closes #20

Generated with [Claude Code](https://claude.ai/code)