### PR TITLE
feat: add Day Time upgrade to increase time per day

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1,7 +1,7 @@
 // ===================== GAME LOGIC =====================
 function startDay(){
   state.phase='PLAYING'; state.paused=false;
-  state.timeLeft=DAY_DURATION; state.dayScore=0; state.catsInBag=0;
+  state.timeLeft=getDayDuration(); state.dayScore=0; state.catsInBag=0;
   state.expanding=false; state.cannonMode=false; state.vacuumMode=false; expandAnim=null; camShakeIntensity=0;
 
   state.activeDayRing = state.progressRing;

--- a/js/state.js
+++ b/js/state.js
@@ -1,8 +1,8 @@
 // ===================== GAME STATE =====================
 const state = {
-  phase: 'MENU', day: 1, timeLeft: DAY_DURATION,
+  phase: 'MENU', day: 1, timeLeft: DAY_DURATION, // updated by getDayDuration() at startDay
   dayScore: 0, totalScore: 0, currency: 0, catsInBag: 0,
-  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, catCannon: 0, catVacuum: 0 },
+  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0 },
   inventory: { toyMouse: 0 },
   paused: false,
   settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'dualAnalog' },
@@ -18,7 +18,8 @@ function getNetRange() { return 3.5 + state.upgrades.netSize * 1.0; }
 function getNetAngle() { return 0.45 + state.upgrades.netSize * 0.1; }
 function getMoveSpeed() { return 4.0 + state.upgrades.walkSpeed * 1.0; }
 function getMaxBag() { return 1 + state.upgrades.bagSize; }
-function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; const l = state.upgrades[type]; return (l + 1) * 2 + Math.floor(l * 0.5); }
+function getDayDuration() { return DAY_DURATION + state.upgrades.dayTime * 10; }
+function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; if (type === 'dayTime') return 10 * Math.pow(10, state.upgrades.dayTime); const l = state.upgrades[type]; return (l + 1) * 2 + Math.floor(l * 0.5); }
 function getCatCountForRing(ring) { return Math.min(8 * Math.pow(2, ring), 128); }
 function getCatDifficulty(ring) { return 1 + ring * 0.35; }
 
@@ -50,6 +51,7 @@ function loadGame() {
       state.upgrades.netSize = data.upgrades.netSize || 0;
       state.upgrades.walkSpeed = data.upgrades.walkSpeed || 0;
       state.upgrades.bagSize = data.upgrades.bagSize || 0;
+      state.upgrades.dayTime = data.upgrades.dayTime || 0;
       state.upgrades.catCannon = data.upgrades.catCannon || 0;
       state.upgrades.catVacuum = data.upgrades.catVacuum || 0;
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -31,6 +31,15 @@ function renderUpgradeCards(){
     if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades[up.key]++;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();saveGame();renderUpgradeCards();});
     c.appendChild(card);
   }
+  // Day Time upgrade
+  {
+    const cost=getUpgradeCost('dayTime'),can=state.currency>=cost;
+    const cur=getDayDuration(),next=cur+10;
+    const card=document.createElement('div');card.className='upgrade-card'+(can?'':' disabled');
+    card.innerHTML=`<div class="upgrade-info"><div class="upgrade-name">⏱️ Day Time <span class="upgrade-level">Lv ${state.upgrades.dayTime}</span></div><div class="upgrade-desc">Time: ${cur}s → ${next}s</div></div><button class="upgrade-btn ${can?'':'cant-afford'}">${cost} 🐱</button>`;
+    if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades.dayTime++;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();saveGame();renderUpgradeCards();});
+    c.appendChild(card);
+  }
   // Cat Cannon one-time unlock
   if(!state.upgrades.catCannon){
     const cost=getUpgradeCost('catCannon'),can=state.currency>=cost;


### PR DESCRIPTION
Add a new "Day Time" upgrade that adds 10 seconds per level to the day duration (base 30s). First upgrade costs 10 cats, with each subsequent level costing 10x the previous.

Closes #23

Generated with [Claude Code](https://claude.ai/code)