### PR TITLE
feat: add trajectory arc indicator for cat cannon

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -35,6 +35,7 @@ function endDay(){
   state.phase='DAY_END';
   state.catsInBag=0; state.cannonMode=false; state.vacuumMode=false;
   vacuumActive=false;
+  arcLine.visible=false; landingMarker.visible=false;
   clearProjectileCats();
   clearVacuumParticles();
   clearToyMice();
@@ -111,6 +112,7 @@ function gameLoop(time){
     updateNet(dt);
     updateVacuum(dt);
     updateProjectileCats(dt);
+    updateCannonArc();
     updateToyMice(dt);
     if(!state.expanding) updateRingDisplay();
     if(crateMesh){const r=crateMesh.children[crateMesh.children.length-1];r.material.opacity=0.2+Math.sin(time*0.003)*0.1;}


### PR DESCRIPTION
Adds a visual trajectory arc indicator for the cat cannon so players can see where their launched cats will land.

- Dashed golden arc line showing predicted projectile path
- Pulsing landing marker ring at the predicted impact point
- Uses same physics constants as the actual projectile
- Properly hidden when cannon mode is off, vacuum mode is active, or day ends

Closes #25

Generated with [Claude Code](https://claude.ai/code)