### PR TITLE
fix: add missing getCrateRadius() and fix upgrade display

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -2,7 +2,7 @@
 const state = {
   phase: 'MENU', day: 1, timeLeft: DAY_DURATION, // updated by getDayDuration() at startDay
   dayScore: 0, totalScore: 0, currency: 0, catsInBag: 0,
-  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0 },
+  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0, crateSize: 0 },
   inventory: { toyMouse: 0 },
   paused: false,
   settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'dualAnalog' },
@@ -21,6 +21,7 @@ function getNetAngle() { return 0.45 + state.upgrades.netSize * 0.1; }
 function getMoveSpeed() { return 4.0 + state.upgrades.walkSpeed * 1.0; }
 function getMaxBag() { return 1 + state.upgrades.bagSize; }
 function getDayDuration() { return DAY_DURATION + state.upgrades.dayTime * 10; }
+function getCrateRadius() { return BASE_CRATE_HIT_RADIUS * (1 + state.upgrades.crateSize * 0.5); }
 function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; if (type === 'dayTime') return 10 * Math.pow(10, state.upgrades.dayTime); const l = state.upgrades[type]; return (l + 1) * 2 + Math.floor(l * 0.5); }
 function getCatCountForRing(ring) { return Math.min(8 * Math.pow(2, ring), 128); }
 function getCatDifficulty(ring) { return 1 + ring * 0.35; }
@@ -35,6 +36,7 @@ function saveGame() {
     totalScore: state.totalScore,
     currency: state.currency,
     upgrades: { ...state.upgrades },
+    inventory: { ...state.inventory },
     progressRing: state.progressRing,
     settings: { ...state.settings },
   };
@@ -57,6 +59,9 @@ function loadGame() {
       state.upgrades.catCannon = data.upgrades.catCannon || 0;
       state.upgrades.catVacuum = data.upgrades.catVacuum || 0;
       state.upgrades.crateSize = data.upgrades.crateSize || 0;
+    }
+    if (data.inventory) {
+      state.inventory.toyMouse = data.inventory.toyMouse || 0;
     }
     state.progressRing = data.progressRing || 0;
     if (data.settings) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -51,7 +51,7 @@ function renderUpgradeCards(){
     {key:'netSize',name:'🥅 Net Size',desc:()=>`Range: ${getNetRange().toFixed(1)} → ${(getNetRange()+1).toFixed(1)}`},
     {key:'walkSpeed',name:'👟 Walk Speed',desc:()=>`Speed: ${getMoveSpeed().toFixed(1)} → ${(getMoveSpeed()+1).toFixed(1)}`},
     {key:'bagSize',name:'🎒 Bag Size',desc:()=>`Capacity: ${getMaxBag()} → ${getMaxBag()+1}`},
-    {key:'crateSize',name:'📦 Crate Size',desc:()=>`Deposit radius: ${getCrateRadius().toFixed(1)} → ${(getCrateRadius()+1.0).toFixed(1)}`},
+    {key:'crateSize',name:'📦 Crate Size',desc:()=>`Deposit radius: ${getCrateRadius().toFixed(1)} → ${(BASE_CRATE_HIT_RADIUS*(1+(state.upgrades.crateSize+1)*0.5)).toFixed(1)}`},
   ];
   c.innerHTML='';
   for(const up of ups){


### PR DESCRIPTION
Fixes #30

## Summary
- Add missing `getCrateRadius()` function that was causing a runtime error breaking upgrade card rendering
- Add `crateSize` to initial state upgrades object
- Fix inventory (toyMouse) save/load persistence
- Fix crate size upgrade description accuracy

## Test plan
- [ ] Complete a day and verify all upgrade cards display (net size, walk speed, bag size, crate size, day time, cat cannon, cat vacuum, toy mouse)
- [ ] Purchase crate size upgrade and verify the crate ring visually expands
- [ ] Purchase toy mouse items, save and reload to verify inventory persists

Generated with [Claude Code](https://claude.ai/code)