### PR TITLE
Add separate Vacuum Strength upgrade independent of Net Size

### DIFF
--- a/js/net.js
+++ b/js/net.js
@@ -311,9 +311,11 @@ const vacuumGroup = new THREE.Group();
 let vacuumActive = false; // true while action button is held in vacuum mode
 let vacuumCaptureTimer = 0;
 const VACUUM_CAPTURE_INTERVAL = 0.25; // seconds between each capture tick
-const VACUUM_RANGE_MULT = 1.5;  // multiplier over net range
-const VACUUM_ANGLE_MULT = 1.5;  // multiplier over net angle
+const VACUUM_RANGE_MULT = 1.5;  // base multiplier over net base range
+const VACUUM_ANGLE_MULT = 1.5;  // base multiplier over net base angle
 const vacuumParticles = [];
+function getVacuumRange() { return 3.5 * VACUUM_RANGE_MULT + state.upgrades.vacuumStrength * 1.0; }
+function getVacuumAngle() { return 0.45 * VACUUM_ANGLE_MULT + state.upgrades.vacuumStrength * 0.1; }
 
 function createVacuum() {
   // Nozzle body (cylinder)
@@ -401,8 +403,8 @@ function vacuumCapture() {
   const fw = new THREE.Vector3(0,0,-1).applyQuaternion(camera.quaternion);
   fw.y=0; if(fw.length()>0.001) fw.normalize();
   const pP = new THREE.Vector3(camera.position.x,0,camera.position.z);
-  const range = getNetRange() * VACUUM_RANGE_MULT;
-  const angle = getNetAngle() * VACUUM_ANGLE_MULT;
+  const range = getVacuumRange();
+  const angle = getVacuumAngle();
   let closest = null, cD = Infinity;
   for(const cat of cats){
     if(cat.caught) continue;

--- a/js/state.js
+++ b/js/state.js
@@ -2,7 +2,7 @@
 const state = {
   phase: 'MENU', day: 1, timeLeft: DAY_DURATION, // updated by getDayDuration() at startDay
   dayScore: 0, totalScore: 0, currency: 0, catsInBag: 0,
-  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0, crateSize: 0 },
+  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0, crateSize: 0, vacuumStrength: 0 },
   inventory: { toyMouse: 0 },
   paused: false,
   settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'dualAnalog' },
@@ -22,7 +22,7 @@ function getMoveSpeed() { return 4.0 + state.upgrades.walkSpeed * 1.0; }
 function getMaxBag() { return 1 + state.upgrades.bagSize; }
 function getDayDuration() { return DAY_DURATION + state.upgrades.dayTime * 10; }
 function getCrateRadius() { return BASE_CRATE_HIT_RADIUS * (1 + state.upgrades.crateSize * 0.5); }
-function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; if (type === 'dayTime') return 10 * Math.pow(10, state.upgrades.dayTime); const l = state.upgrades[type]; return (l + 1) * 2 + Math.floor(l * 0.5); }
+function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; if (type === 'dayTime') return 10 * Math.pow(10, state.upgrades.dayTime); const l = state.upgrades[type] || 0; return (l + 1) * 2 + Math.floor(l * 0.5); }
 function getCatCountForRing(ring) { return Math.min(8 * Math.pow(2, ring), 128); }
 function getCatDifficulty(ring) { return 1 + ring * 0.35; }
 
@@ -59,6 +59,7 @@ function loadGame() {
       state.upgrades.catCannon = data.upgrades.catCannon || 0;
       state.upgrades.catVacuum = data.upgrades.catVacuum || 0;
       state.upgrades.crateSize = data.upgrades.crateSize || 0;
+      state.upgrades.vacuumStrength = data.upgrades.vacuumStrength || 0;
     }
     if (data.inventory) {
       state.inventory.toyMouse = data.inventory.toyMouse || 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -86,6 +86,14 @@ function renderUpgradeCards(){
     if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades.catVacuum=1;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();saveGame();renderUpgradeCards();});
     c.appendChild(card);
   }
+  // Vacuum Strength upgrade (only if vacuum is unlocked)
+  if(state.upgrades.catVacuum){
+    const cost=getUpgradeCost('vacuumStrength'),can=state.currency>=cost;
+    const card=document.createElement('div');card.className='upgrade-card'+(can?'':' disabled');
+    card.innerHTML=`<div class="upgrade-info"><div class="upgrade-name">🌀 Vacuum Strength <span class="upgrade-level">Lv ${state.upgrades.vacuumStrength}</span></div><div class="upgrade-desc">Range: ${getVacuumRange().toFixed(1)} → ${(getVacuumRange()+1).toFixed(1)}</div></div><button class="upgrade-btn ${can?'':'cant-afford'}">${cost} 🐱</button>`;
+    if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades.vacuumStrength++;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();saveGame();renderUpgradeCards();});
+    c.appendChild(card);
+  }
   // Toy Mouse consumable
   {
     const cost=TOY_MOUSE_COST,can=state.currency>=cost;


### PR DESCRIPTION
Closes #34

## Summary
- Added a dedicated `vacuumStrength` upgrade so the vacuum and net have independent upgrade paths
- Added `getVacuumRange()` and `getVacuumAngle()` functions for vacuum-specific scaling
- Vacuum Strength upgrade card appears in the shop after the vacuum is unlocked

## Test plan
- [ ] Verify Net Size upgrade only affects net range/angle
- [ ] Verify Vacuum Strength upgrade only appears after buying the vacuum
- [ ] Verify Vacuum Strength upgrade correctly increases vacuum range
- [ ] Verify save/load preserves vacuumStrength upgrade level

Generated with [Claude Code](https://claude.ai/claude-code)