### PR TITLE
feat: replace mobile swing button with double-tap joystick activation

### DIFF
--- a/js/controls.js
+++ b/js/controls.js
@@ -14,14 +14,19 @@ function requestPointerLock(){if(!isMobile) renderer.domElement.requestPointerLo
 // ===================== MOBILE CONTROLS =====================
 const mobileInput={moveX:0,moveY:0,lookX:0,lookY:0};
 let aimButtonHeld=false;
+// Double-tap tracking for left joystick tool activation
+let lastJoystickTouchEnd=0;
+let doubleTapToolActive=false;
+const DOUBLE_TAP_THRESHOLD=300; // ms window for double-tap detection
 function setupMobileControls(){
   const btnSwing=document.getElementById('btn-swing'),btnDeposit=document.getElementById('btn-deposit'),hudPause=document.getElementById('hud-pause');
-  function makeDJ(zId,bId,kId,onM,onE){
+  function makeDJ(zId,bId,kId,onM,onE,onStart){
     const zone=document.getElementById(zId),base=document.getElementById(bId),knob=document.getElementById(kId);
     let tId=null,oX=0,oY=0;const jR=70,kR=28,maxR=jR-kR;
     zone.addEventListener('touchstart',e=>{e.preventDefault();if(tId!==null)return;const t=e.changedTouches[0];tId=t.identifier;oX=t.clientX;oY=t.clientY;
     base.style.cssText=`position:fixed;left:${oX-jR}px;top:${oY-jR}px;width:140px;height:140px;border-radius:50%;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);`;
     knob.style.cssText=`position:fixed;left:${oX}px;top:${oY}px;width:56px;height:56px;border-radius:50%;background:rgba(255,255,255,0.45);border:2px solid rgba(255,255,255,0.4);transform:translate(-50%,-50%);`;
+    if(onStart) onStart();
     onM(0,0);},{passive:false});
     zone.addEventListener('touchmove',e=>{e.preventDefault();for(const t of e.changedTouches){if(t.identifier!==tId)continue;let dx=t.clientX-oX,dy=t.clientY-oY;const d=Math.sqrt(dx*dx+dy*dy);if(d>maxR){dx*=maxR/d;dy*=maxR/d;}
     knob.style.left=(oX+dx)+'px';knob.style.top=(oY+dy)+'px';
@@ -42,6 +47,24 @@ function setupMobileControls(){
   },()=>{
     if(state.settings.controllerMode==='goldenEye') geOnEnd();
     else{mobileInput.moveX=0;mobileInput.moveY=0;}
+    // Record touch-end time for double-tap detection
+    lastJoystickTouchEnd=Date.now();
+    // Deactivate held tools if double-tap tool was active
+    if(doubleTapToolActive){
+      doubleTapToolActive=false;
+      if(state.vacuumMode) stopVacuum();
+      if(state.cannonMode) stopCannonFire();
+    }
+  },()=>{
+    // onStart callback: check for double-tap
+    if(state.phase!=='PLAYING'||state.expanding) return;
+    const now=Date.now();
+    if(now-lastJoystickTouchEnd<DOUBLE_TAP_THRESHOLD){
+      doubleTapToolActive=true;
+      if(state.cannonMode) startCannonFire();
+      else if(state.vacuumMode) startVacuum();
+      else startSwing();
+    }
   });
   makeDJ('joystick-zone-right','joystick-base-right','joystick-knob-right',(x,y)=>{mobileInput.lookX=x;mobileInput.lookY=y;},()=>{mobileInput.lookX=0;mobileInput.lookY=0;});
   // Aim button for GoldenEye mode
@@ -51,9 +74,8 @@ function setupMobileControls(){
     btnAim.addEventListener('touchend',e=>{aimButtonHeld=false;btnAim.classList.remove('held');mobileInput.lookX=0;mobileInput.lookY=0;});
     btnAim.addEventListener('touchcancel',e=>{aimButtonHeld=false;btnAim.classList.remove('held');mobileInput.lookX=0;mobileInput.lookY=0;});
   }
-  btnSwing.addEventListener('touchstart',e=>{e.preventDefault();if(state.cannonMode) startCannonFire(); else if(state.vacuumMode) startVacuum(); else startSwing();},{passive:false});
-  btnSwing.addEventListener('touchend',e=>{if(state.vacuumMode) stopVacuum(); if(state.cannonMode) stopCannonFire();});
-  btnSwing.addEventListener('touchcancel',e=>{if(state.vacuumMode) stopVacuum(); if(state.cannonMode) stopCannonFire();});
+  // Hide the swing button on mobile — tool activation is now via double-tap on joystick
+  if(btnSwing) btnSwing.style.display='none';
   const btnCannon=document.getElementById('btn-cannon');
   if(btnCannon) btnCannon.addEventListener('touchstart',e=>{e.preventDefault();toggleCannonMode();},{passive:false});
   const btnVacuum=document.getElementById('btn-vacuum');
@@ -128,8 +150,8 @@ function updatePlayer(dt) {
     if(bm) bm.classList.toggle('visible',state.inventory.toyMouse>0);
   }
   const nc=isNearCrate();
-  if(state.cannonMode){if(state.catsInBag>0) showCenterMsg("Cannon mode! Click to shoot · Q to switch"); else showCenterMsg("No cats to shoot! Q to switch back");}
-  else if(state.vacuumMode){if(state.catsInBag>=getMaxBag()) showCenterMsg("Bag full! Return to crate · V to switch"); else showCenterMsg("Vacuum mode! Hold click to suck · V to switch");}
+  if(state.cannonMode){if(state.catsInBag>0) showCenterMsg(isMobile?"Cannon mode! Double-tap stick to shoot":"Cannon mode! Click to shoot · Q to switch"); else showCenterMsg(isMobile?"No cats to shoot!":"No cats to shoot! Q to switch back");}
+  else if(state.vacuumMode){if(state.catsInBag>=getMaxBag()) showCenterMsg(isMobile?"Bag full! Return to crate":"Bag full! Return to crate · V to switch"); else showCenterMsg(isMobile?"Vacuum mode! Double-tap & hold stick to suck":"Vacuum mode! Hold click to suck · V to switch");}
   else if(!isMobile){const extras=[];if(state.upgrades.catCannon) extras.push("Q for cannon");if(state.upgrades.catVacuum) extras.push("V for vacuum");if(state.inventory.toyMouse>0) extras.push("T for toy mouse");const suffix=extras.length?" · "+extras.join(" · "):"";if(nc&&state.catsInBag>0) showCenterMsg("Press E to deposit"+suffix); else if(state.catsInBag>=getMaxBag()) showCenterMsg("Bag full! Return to crate"+(state.upgrades.catCannon?" or use cannon (Q)":"")); else hideCenterMsg();}
   else{if(state.catsInBag>=getMaxBag()&&!nc) showCenterMsg("Bag full! Return to crate"); else hideCenterMsg();}
 }


### PR DESCRIPTION
Closes #35

On mobile, players now double-tap (and hold) the left analog stick to activate the current tool (net swing, cannon fire, or vacuum) instead of using a separate button.

- 300ms double-tap detection threshold
- Held tools (vacuum/cannon) deactivate on joystick release
- Net swing fires immediately on double-tap
- Swing button hidden on mobile
- Desktop controls unchanged

Generated with [Claude Code](https://claude.ai/code)