### PR TITLE
Add cat rate upgrade for vacuum multi-capture

### DIFF
--- a/js/net.js
+++ b/js/net.js
@@ -405,17 +405,21 @@ function vacuumCapture() {
   const pP = new THREE.Vector3(camera.position.x,0,camera.position.z);
   const range = getVacuumRange();
   const angle = getVacuumAngle();
-  let closest = null, cD = Infinity;
+  const rate = getCatRate();
+  // Collect cats in range, sorted by distance
+  const inRange = [];
   for(const cat of cats){
     if(cat.caught) continue;
     const tC = new THREE.Vector3(cat.mesh.position.x,0,cat.mesh.position.z).sub(pP);
     const d = tC.length();
     if(d > range) continue;
     if(d > 0.01){ tC.normalize(); if(Math.acos(Math.min(fw.dot(tC),1)) > angle) continue; }
-    if(d < cD){ cD=d; closest=cat; }
+    inRange.push({ cat, dist: d });
   }
-  if(closest) {
-    catchCat(closest);
+  inRange.sort((a, b) => a.dist - b.dist);
+  const toCapture = Math.min(rate, inRange.length, getMaxBag() - state.catsInBag);
+  for(let i = 0; i < toCapture; i++) {
+    catchCat(inRange[i].cat);
   }
 }
 

--- a/js/state.js
+++ b/js/state.js
@@ -2,7 +2,7 @@
 const state = {
   phase: 'MENU', day: 1, timeLeft: DAY_DURATION, // updated by getDayDuration() at startDay
   dayScore: 0, totalScore: 0, currency: 0, catsInBag: 0,
-  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0, crateSize: 0, vacuumStrength: 0 },
+  upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0, crateSize: 0, vacuumStrength: 0, catRate: 0 },
   inventory: { toyMouse: 0 },
   paused: false,
   settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'dualAnalog' },
@@ -22,7 +22,8 @@ function getMoveSpeed() { return 4.0 + state.upgrades.walkSpeed * 1.0; }
 function getMaxBag() { return 1 + state.upgrades.bagSize; }
 function getDayDuration() { return DAY_DURATION + state.upgrades.dayTime * 10; }
 function getCrateRadius() { return BASE_CRATE_HIT_RADIUS * (1 + state.upgrades.crateSize * 0.5); }
-function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; if (type === 'dayTime') return 10 * Math.pow(10, state.upgrades.dayTime); const l = state.upgrades[type] || 0; return (l + 1) * 2 + Math.floor(l * 0.5); }
+function getCatRate() { return 1 + state.upgrades.catRate; }
+function getUpgradeCost(type) { if (type === 'catCannon' || type === 'catVacuum') return 16; if (type === 'dayTime') return 10 * Math.pow(10, state.upgrades.dayTime); if (type === 'catRate') return (state.upgrades.catRate + 1) * 100; const l = state.upgrades[type] || 0; return (l + 1) * 2 + Math.floor(l * 0.5); }
 function getCatCountForRing(ring) { const exp = 8 * Math.pow(2, ring); return exp <= 128 ? exp : 128 * (ring - 3); }
 function getCatDifficulty(ring) { return 1 + ring * 0.35; }
 
@@ -60,6 +61,7 @@ function loadGame() {
       state.upgrades.catVacuum = data.upgrades.catVacuum || 0;
       state.upgrades.crateSize = data.upgrades.crateSize || 0;
       state.upgrades.vacuumStrength = data.upgrades.vacuumStrength || 0;
+      state.upgrades.catRate = data.upgrades.catRate || 0;
     }
     if (data.inventory) {
       state.inventory.toyMouse = data.inventory.toyMouse || 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -94,6 +94,14 @@ function renderUpgradeCards(){
     if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades.vacuumStrength++;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();saveGame();renderUpgradeCards();});
     c.appendChild(card);
   }
+  // Cat Rate upgrade (only if vacuum is unlocked)
+  if(state.upgrades.catVacuum){
+    const cost=getUpgradeCost('catRate'),can=state.currency>=cost;
+    const card=document.createElement('div');card.className='upgrade-card'+(can?'':' disabled');
+    card.innerHTML=`<div class="upgrade-info"><div class="upgrade-name">🌀 Cat Rate <span class="upgrade-level">Lv ${state.upgrades.catRate}</span></div><div class="upgrade-desc">Vacuum captures: x${getCatRate()} → x${getCatRate()+1} cats per tick</div></div><button class="upgrade-btn ${can?'':'cant-afford'}">${cost} 🐱</button>`;
+    if(can) card.querySelector('.upgrade-btn').addEventListener('click',()=>{state.currency-=cost;state.upgrades.catRate++;document.getElementById('currency-display').textContent=state.currency;playUpgradeSound();saveGame();renderUpgradeCards();});
+    c.appendChild(card);
+  }
   // Toy Mouse consumable
   {
     const cost=TOY_MOUSE_COST,can=state.currency>=cost;


### PR DESCRIPTION
Adds a "Cat Rate" upgrade that multiplies how many cats the vacuum captures per tick. Starts at x1, each upgrade adds +1. Cost starts at 100 and increases by 100 per purchase.

Closes #42

Generated with [Claude Code](https://claude.ai/code)