### PR TITLE
Replace GoldenEye controller with Single Analog scheme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -79,6 +79,12 @@ canvas { display: block; touch-action: none; }
 .controller-option { flex: 1; background: rgba(255,255,255,0.05); color: #E8C9A0; border: none; font-family: 'Fredoka', sans-serif; font-size: 0.85rem; padding: 8px 12px; cursor: pointer; transition: background 0.2s, color 0.2s; -webkit-tap-highlight-color: transparent; }
 .controller-option.active { background: rgba(232,130,42,0.7); color: #fff; }
 .controller-option:not(.active):active { background: rgba(232,130,42,0.3); }
+/* ===================== STICK POSITION TOGGLE ===================== */
+.stick-position-row { display: none; flex-direction: column; gap: 8px; }
+.stick-position-toggle { display: flex; gap: 0; border-radius: 8px; overflow: hidden; border: 2px solid rgba(232,130,42,0.5); }
+.stick-position-option { flex: 1; background: rgba(255,255,255,0.05); color: #E8C9A0; border: none; font-family: 'Fredoka', sans-serif; font-size: 0.85rem; padding: 8px 12px; cursor: pointer; transition: background 0.2s, color 0.2s; -webkit-tap-highlight-color: transparent; }
+.stick-position-option.active { background: rgba(232,130,42,0.7); color: #fff; }
+.stick-position-option:not(.active):active { background: rgba(232,130,42,0.3); }
 
 .hud-pause { display: none; font-size: 1.5rem; pointer-events: auto; cursor: pointer; padding: 4px 8px; opacity: 0.7; -webkit-tap-highlight-color: transparent; }
 @media (max-width: 600px) { .hud-pause { display: block; } }
@@ -114,10 +120,6 @@ canvas { display: block; touch-action: none; }
 .btn-mouse { bottom: 260px; left: 22px; width: 64px; height: 64px; background: rgba(180,140,80,0.55); border: 3px solid rgba(180,140,80,0.7); font-size: 1.5rem; opacity: 0; transition: opacity 0.2s; pointer-events: none; }
 .btn-mouse.visible { opacity: 1; pointer-events: auto; }
 .btn-mouse:active { background: rgba(180,140,80,0.85); }
-.btn-aim { bottom: 50px; left: 50%; transform: translateX(-50%); width: 72px; height: 72px; background: rgba(160,160,220,0.45); border: 3px solid rgba(160,160,220,0.6); font-size: 1.5rem; display: none; }
-.btn-aim.visible { display: flex; }
-.btn-aim.held { background: rgba(160,160,220,0.85); border-color: rgba(200,200,255,0.9); }
-.btn-aim:active { background: rgba(160,160,220,0.85); }
 
 /* ===================== HUD INVENTORY INDICATOR ===================== */
 .hud-inventory { background: rgba(0,0,0,0.5); border-radius: 12px; padding: 8px 16px; color: #E8C9A0; font-size: 1rem; font-family: 'Fredoka', sans-serif; border: 2px solid rgba(180,140,80,0.4); }

--- a/index.html
+++ b/index.html
@@ -17,8 +17,16 @@
     <div class="setting-row controller-mode-row" id="controller-mode-row">
       <span class="setting-label">Controller</span>
       <div class="controller-toggle" id="controller-toggle">
-        <button class="controller-option active" id="opt-dualAnalog" data-mode="dualAnalog">Dual Analog</button>
-        <button class="controller-option" id="opt-goldenEye" data-mode="goldenEye">GoldenEye</button>
+        <button class="controller-option" id="opt-dualAnalog" data-mode="dualAnalog">Dual Analog</button>
+        <button class="controller-option active" id="opt-singleAnalog" data-mode="singleAnalog">Single Analog</button>
+      </div>
+    </div>
+    <div class="setting-row stick-position-row" id="stick-position-row">
+      <span class="setting-label">Stick Position</span>
+      <div class="stick-position-toggle" id="stick-position-toggle">
+        <button class="stick-position-option" data-position="left">Left</button>
+        <button class="stick-position-option active" data-position="middle">Middle</button>
+        <button class="stick-position-option" data-position="right">Right</button>
       </div>
     </div>
     <label class="setting-row"><span class="setting-label">Look Sensitivity</span><input type="range" id="setting-sensitivity" min="1" max="5" step="0.25" value="2.5"><span class="setting-value" id="sensitivity-value">2.5</span></label>
@@ -48,7 +56,6 @@
   <div class="mobile-btn btn-cannon" id="btn-cannon">🔫</div>
   <div class="mobile-btn btn-vacuum" id="btn-vacuum">🌀</div>
   <div class="mobile-btn btn-mouse" id="btn-mouse">🐭</div>
-  <div class="mobile-btn btn-aim" id="btn-aim"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/></svg></div>
 </div>
 <div class="day-intro" id="day-intro"></div>
 <div id="upgrade-screen">

--- a/js/state.js
+++ b/js/state.js
@@ -5,7 +5,7 @@ const state = {
   upgrades: { netSize: 0, walkSpeed: 0, bagSize: 0, dayTime: 0, catCannon: 0, catVacuum: 0, crateSize: 0, vacuumStrength: 0, catRate: 0 },
   inventory: { toyMouse: 0 },
   paused: false,
-  settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'dualAnalog' },
+  settings: { lookSensitivity: 2.5, deadZone: 0.15, controllerMode: 'singleAnalog', stickPosition: 'middle' },
   progressRing: 0,
   activeDayRing: 0,
   expanding: false,
@@ -70,7 +70,11 @@ function loadGame() {
     if (data.settings) {
       state.settings.lookSensitivity = data.settings.lookSensitivity ?? 2.5;
       state.settings.deadZone = data.settings.deadZone ?? 0.15;
-      state.settings.controllerMode = data.settings.controllerMode ?? 'dualAnalog';
+      // Migrate old controllerMode values
+      let cm = data.settings.controllerMode ?? 'singleAnalog';
+      if(cm === 'goldenEye') cm = 'singleAnalog';
+      state.settings.controllerMode = cm;
+      state.settings.stickPosition = data.settings.stickPosition ?? 'middle';
     }
     return true;
   } catch(e) { return false; }


### PR DESCRIPTION
Replace GoldenEye controller with Single Analog scheme

- Remove GoldenEye controller mode and aim button
- Add Single Analog mode: left/right rotates player, up/down moves forward/backward
- Add stick position setting (left/middle/right) in settings menu
- No pitch changes in Single Analog mode (player never looks up/down)
- Migrate existing saves from goldenEye to singleAnalog

Closes #46

Generated with [Claude Code](https://claude.ai/code)