### PR TITLE
feat: add action button for single analog mode, fix center stick position

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <span class="setting-label">Stick Position</span>
       <div class="stick-position-toggle" id="stick-position-toggle">
         <button class="stick-position-option" data-position="left">Left</button>
-        <button class="stick-position-option active" data-position="middle">Middle</button>
+        <button class="stick-position-option active" data-position="middle">Center</button>
         <button class="stick-position-option" data-position="right">Right</button>
       </div>
     </div>


### PR DESCRIPTION
Closes #48

- Disable double-tap tool activation in single analog mode, add general action button
- Fix center stick position (60% centered instead of 100% width)
- Update mobile hint messages for single analog mode

Generated with [Claude Code](https://claude.ai/code)